### PR TITLE
Fix archive functionality: resolve IndexedDB constraint error

### DIFF
--- a/scripts/modules/indexedDBStorage.js
+++ b/scripts/modules/indexedDBStorage.js
@@ -233,7 +233,8 @@ class IndexedDBStorage {
                     const archivedTasks = board.archivedTasks.map(task => ({
                         ...task,
                         boardId: board.id,
-                        id: task.id || generateUniqueId(),
+                        id: `archived_${task.id || generateUniqueId()}`,
+                        originalTaskId: task.id,
                         isArchived: true,
                         createdDate: task.createdDate || new Date().toISOString(),
                         lastModified: new Date().toISOString()
@@ -399,7 +400,11 @@ class IndexedDBStorage {
             
             // Get archived tasks for this board
             const archivedTasks = (data.tasks || [])
-                .filter(task => task.boardId === board.id && task.isArchived);
+                .filter(task => task.boardId === board.id && task.isArchived)
+                .map(task => ({
+                    ...task,
+                    id: task.originalTaskId || task.id.replace(/^archived_/, '')
+                }));
 
             return {
                 ...board,


### PR DESCRIPTION
Fixes # 

This PR resolves the "data storage failed" error when archiving tasks in the Done column.

## Problem
Archiving tasks failed with `ConstraintError: Key already exists in the object store` because archived tasks retained the same ID as their original tasks, causing key conflicts in IndexedDB.

## Solution
- Prefix archived task IDs with `archived_` to create unique storage keys
- Store original task ID in `originalTaskId` field for reference
- Restore original task IDs when loading archived tasks from storage

## Testing
Tested with the existing codebase structure and confirmed the fix resolves the IndexedDB constraint error.

Generated with [Claude Code](https://claude.ai/code)